### PR TITLE
Fix/directors grid layout

### DIFF
--- a/app/(pages)/about-us/_components/CloudBackground/CloudBackground.module.scss
+++ b/app/(pages)/about-us/_components/CloudBackground/CloudBackground.module.scss
@@ -4,7 +4,12 @@
     background-image: 
         url('/images/cloud_background/TopClouds.svg'),
         url('/images/cloud_background/Sand.svg'),
-        linear-gradient(to bottom, var(--sky-background) 0%, #D5FCD1 100%);
+        linear-gradient(to bottom, 
+            white 0%,   
+            white 5%,   
+            var(--sky-background) 10%, 
+            #D5FCD1 100%, 
+        );
     background-repeat: no-repeat, no-repeat, no-repeat;
     background-size: contain, contain, cover; /* Clouds: Contain | Sand: Cover | Gradient: Cover */
     background-position: top center, bottom center, center;
@@ -15,6 +20,7 @@
     height: 1976px; /* Full screen height */
     width: 100%;
     position: relative;
+    margin-top: -5px;
 
     .child1 {
         background-image: url('/images/cloud_background/LeftClouds.svg');

--- a/app/(pages)/about-us/_components/OurTeam/OurTeam.module.scss
+++ b/app/(pages)/about-us/_components/OurTeam/OurTeam.module.scss
@@ -111,7 +111,6 @@
             display: grid;
             grid-template-columns: repeat(4, 1fr); // Always four columns
             gap: 4%;
-            border: 1px solid red;
         }
     }
 
@@ -132,7 +131,6 @@
             height: 100%;
             // max-width: 1440px;
             padding: 0% 13% 5% 13%;
-            border: 1px solid black;
     
             &_title{
                 display: flex;

--- a/app/(pages)/about-us/_components/OurTeam/OurTeam.module.scss
+++ b/app/(pages)/about-us/_components/OurTeam/OurTeam.module.scss
@@ -224,7 +224,7 @@
     
             &_team{
                 display: grid;
-                grid-template-columns: repeat(4, 1fr); // Always four columns
+                grid-template-columns: repeat(3, 1fr); // Always four columns
                 gap: 3%;
                 padding-bottom: 2%;
             }

--- a/app/(pages)/about-us/_components/OurTeam/OurTeam.module.scss
+++ b/app/(pages)/about-us/_components/OurTeam/OurTeam.module.scss
@@ -13,7 +13,7 @@
         width: 100%;
         height: 100%;
         // max-width: 1440px;
-        padding: 0% 13% 5% 13%;
+        padding: 0% 13%;
     
         // border: 1px solid black;
 
@@ -130,7 +130,7 @@
             width: 100%;
             height: 100%;
             // max-width: 1440px;
-            padding: 0% 13% 5% 13%;
+            padding: 0% 13%;
     
             &_title{
                 display: flex;
@@ -247,7 +247,7 @@
             width: 100%;
             height: 100%;
             // max-width: 1440px;
-            padding: 0% 13% 5% 13%;
+            padding: 0% 13%;
         
             // border: 1px solid black;
     

--- a/app/(pages)/about-us/_components/OurTeam/OurTeam.module.scss
+++ b/app/(pages)/about-us/_components/OurTeam/OurTeam.module.scss
@@ -1,9 +1,9 @@
-$bg-color: #FFFFFF;
+@import '@globals/styles/mixins.scss';
 
 .ourTeam{
     display: flex;
     flex-direction: column;
-    background-color: $bg-color;
+    background-color: var(--background-light);
     align-items: center;
 
     &_container{
@@ -13,7 +13,7 @@ $bg-color: #FFFFFF;
         width: 100%;
         height: 100%;
         // max-width: 1440px;
-        padding: 0% 13%;
+        padding: 0% 13% 5% 13%;
     
         // border: 1px solid black;
 
@@ -24,7 +24,7 @@ $bg-color: #FFFFFF;
             margin-bottom: 48px;
             
             h1{
-                color: #123041;
+                color: var(--sea-background);
                 font-family: Metropolis;
                 font-size: 40px;
                 font-style: normal;
@@ -109,11 +109,248 @@ $bg-color: #FFFFFF;
 
         &_team{
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-            gap: 48.5px;
-            // border: 1px solid red;
+            grid-template-columns: repeat(4, 1fr); // Always four columns
+            gap: 4%;
+            border: 1px solid red;
         }
     }
 
+}
+
+@include tablet {
+    .ourTeam{
+        display: flex;
+        flex-direction: column;
+        background-color: var(--background-light);
+        align-items: center;
+    
+        &_container{
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            width: 100%;
+            height: 100%;
+            // max-width: 1440px;
+            padding: 0% 13% 5% 13%;
+            border: 1px solid black;
+    
+            &_title{
+                display: flex;
+                flex-direction: column;
+                gap: 16px;
+                margin-bottom: 48px;
+                
+                h1{
+                    color: var(--sea-background);
+                    font-family: Metropolis;
+                    font-size: 40px;
+                    font-style: normal;
+                    font-weight: 700;
+                    line-height: normal;
+                    letter-spacing: 0.8px;
+                }
+            
+                p{
+                    color: #123041;
+                    text-shadow: 0px 4px 50px rgba(47, 172, 184, 0.15);
+                    font-family: Metropolis;
+                    font-size: 16px;
+                    font-style: normal;
+                    font-weight: 400;
+                    line-height: 150%; /* 24px */
+                    letter-spacing: 0.32px;
+                }
+            }
+    
+            &_embla {
+                width: 100%;
+                
+                &_filterButtons{
+                    display: flex;
+                    flex-direction: row;
+                    justify-content: flex-start;
+                    align-items: center;
+                    gap: 16px;
+                    margin-bottom: 48px;
+                    // border: 1px solid black;
+        
+                    &_button{
+                        display: flex;
+                        flex-direction: row;
+                        height: 48px;
+                        padding: 12px 24px;
+                        justify-content: center;
+                        align-items: center;
+                        gap: 10px;
+                        border-radius: 100px;
+                        background: #DCE0E3;
+                        cursor: pointer;
+        
+                        p{
+                            color: #123041;
+                            text-align: center;
+                            font-family: "Metropolis";
+                            font-size: 15px;
+                            font-style: normal;
+                            font-weight: 700;
+                            line-height: normal;
+                            letter-spacing: 0.36px;
+                        }
+        
+                        &.active{
+                            display: flex;
+                            flex-direction: row;
+                            height: 48px;
+                            padding: 12px 24px;
+                            justify-content: center;
+                            align-items: center;
+                            gap: 10px;
+                            border-radius: 100px;
+                            background: var(--text-dark);
+        
+                            p{
+                                color: var(--text-light);
+                                text-align: center;
+                                font-family: "Metropolis";
+                                font-size: 18px;
+                                font-style: normal;
+                                font-weight: 700;
+                                line-height: normal;
+                                letter-spacing: 0.36px;
+                            }
+                        }
+                    }
+                }
+            }
+    
+    
+            &_team{
+                display: grid;
+                grid-template-columns: repeat(4, 1fr); // Always four columns
+                gap: 3%;
+                padding-bottom: 2%;
+            }
+        }
+    
+    }
+}
+
+@include phone {
+    .ourTeam{
+        display: flex;
+        flex-direction: column;
+        background-color: var(--background-light);
+        align-items: center;
+    
+        &_container{
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            width: 100%;
+            height: 100%;
+            // max-width: 1440px;
+            padding: 0% 13% 5% 13%;
+        
+            // border: 1px solid black;
+    
+            &_title{
+                display: flex;
+                flex-direction: column;
+                gap: 16px;
+                margin-bottom: 48px;
+                
+                h1{
+                    color: var(--sea-background);
+                    font-family: Metropolis;
+                    font-size: 40px;
+                    font-style: normal;
+                    font-weight: 700;
+                    line-height: normal;
+                    letter-spacing: 0.8px;
+                }
+            
+                p{
+                    color: #123041;
+                    text-shadow: 0px 4px 50px rgba(47, 172, 184, 0.15);
+                    font-family: Metropolis;
+                    font-size: 16px;
+                    font-style: normal;
+                    font-weight: 400;
+                    line-height: 150%; /* 24px */
+                    letter-spacing: 0.32px;
+                }
+            }
+    
+            &_embla {
+                width: 100%;
+                
+                &_filterButtons{
+                    display: flex;
+                    flex-direction: row;
+                    justify-content: flex-start;
+                    align-items: center;
+                    gap: 16px;
+                    margin-bottom: 48px;
+                    // border: 1px solid black;
+        
+                    &_button{
+                        display: flex;
+                        flex-direction: row;
+                        height: 48px;
+                        padding: 12px 24px;
+                        justify-content: center;
+                        align-items: center;
+                        gap: 10px;
+                        border-radius: 100px;
+                        background: #DCE0E3;
+                        cursor: pointer;
+        
+                        p{
+                            color: #123041;
+                            text-align: center;
+                            font-family: "Metropolis";
+                            font-size: 18px;
+                            font-style: normal;
+                            font-weight: 700;
+                            line-height: normal;
+                            letter-spacing: 0.36px;
+                        }
+        
+                        &.active{
+                            display: flex;
+                            flex-direction: row;
+                            height: 48px;
+                            padding: 12px 24px;
+                            justify-content: center;
+                            align-items: center;
+                            gap: 10px;
+                            border-radius: 100px;
+                            background: #123041;
+        
+                            p{
+                                color: #FFFFFF;
+                                text-align: center;
+                                font-family: "Metropolis";
+                                font-size: 18px;
+                                font-style: normal;
+                                font-weight: 700;
+                                line-height: normal;
+                                letter-spacing: 0.36px;
+                            }
+                        }
+                    }
+                }
+            }
+    
+    
+            &_team{
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+                gap: 48.5px;
+                // border: 1px solid red;
+            }
+        }
+    
+    }
 }
 

--- a/app/(pages)/about-us/_components/OurTeam/OurTeam.tsx
+++ b/app/(pages)/about-us/_components/OurTeam/OurTeam.tsx
@@ -73,12 +73,12 @@ export default function OurTeam() {
 
   const teamNames = [
     'Design',
+    'Technical',
     'External',
     'Finance',
     'Marketing',
     'Operations',
     'Sponsorship',
-    'Technical',
   ];
 
   return (

--- a/app/(pages)/about-us/_components/OurTeam/_components/ProfileCard.module.scss
+++ b/app/(pages)/about-us/_components/OurTeam/_components/ProfileCard.module.scss
@@ -1,3 +1,4 @@
+@import '@globals/styles/mixins.scss';
 .profile_card{
   gap: 8px;
   display: flex;


### PR DESCRIPTION
Updated the directors section alongside clouds background section on about-us. For directors, made the directors span a row of 4 directors on desktop all sizes (for tablet, I left it 3 and the others are responsive based off screen width). For cloud, fixed it so that there is no line at start of section.